### PR TITLE
Remove obsolete Migrate --group parameter.

### DIFF
--- a/scripts/enable_modules.sh
+++ b/scripts/enable_modules.sh
@@ -7,7 +7,7 @@ source $(dirname $0)/site_config.sh
 
 "$drush" -y pm:enable media_thumbnails_tiff
 
-"$drush" -y migrate:import islandora_tags,islandora_defaults_tags
+"$drush" -y migrate:import islandora_tags
 
 "$drush" -y then olivero
 "$drush" -y config-set system.theme default olivero

--- a/scripts/enable_modules.sh
+++ b/scripts/enable_modules.sh
@@ -7,7 +7,7 @@ source $(dirname $0)/site_config.sh
 
 "$drush" -y pm:enable media_thumbnails_tiff
 
-"$drush" -y migrate:import --group=islandora
+"$drush" -y migrate:import islandora_tags,islandora_defaults_tags
 
 "$drush" -y then olivero
 "$drush" -y config-set system.theme default olivero


### PR DESCRIPTION
enables.module.sh shows the error " invalid option:--group". Making the migrations explicit fixes this.