### PR TITLE
Remove advanced search config

### DIFF
--- a/scripts/partial_config_sych.sh
+++ b/scripts/partial_config_sych.sh
@@ -2,9 +2,6 @@
 
 source $(dirname $0)/site_config.sh
 
-# import advanced search configs
-"$drush" -y config-import --partial --source="$islandora_lite_installation_path"/configs/advanced_search
-
 # rest config
 "$drush" -y config-import --partial --source="$islandora_lite_installation_path"/configs/rest
 


### PR DESCRIPTION
Running the partial_config_sycn.sh script shows an error that no configuration directory exists called "advanced_search"

